### PR TITLE
feat(tracking): ajouter la méthode getLatestEvent() dans FedexTrackin…

### DIFF
--- a/src/Service/FedexTrackingService.php
+++ b/src/Service/FedexTrackingService.php
@@ -74,4 +74,10 @@ class FedexTrackingService
         }
     }
 
+    public function getLatestEvent(string $trackingNumber, string $locale = 'fr_FR'): ?FedexTrackingEvent
+    {
+        $events = $this->trackShipment($trackingNumber, includeDetailedScans: true, locale: $locale);
+        return $events[0] ?? null;
+    }
+
 }


### PR DESCRIPTION
feat(tracking): ajouter la méthode getLatestEvent() dans FedexTrackingService (#2)

- Nouvelle méthode pour récupérer le dernier événement de suivi
- Utilise le tri par date pour renvoyer l'événement le plus récent
- Facilite l'accès rapide aux informations de tracking