### PR TITLE
feat(cli): créer la commande fedex:track pour afficher les événements…

### DIFF
--- a/src/Command/FedexTrackCommand.php
+++ b/src/Command/FedexTrackCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace SonnyDev\FedexBundle\Command;
+
+use SonnyDev\FedexBundle\Dto\FedexTrackingEvent;
+use SonnyDev\FedexBundle\Service\FedexTrackingService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'fedex:track',
+    description: 'Affiche les événements de suivi FedEx pour un numéro de tracking.'
+)]
+class FedexTrackCommand extends Command
+{
+    public function __construct(
+        private readonly FedexTrackingService $trackingService
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('trackingNumber', InputArgument::REQUIRED, 'Numéro de suivi FedEx (tracking).')
+            ->addOption('locale', null, InputOption::VALUE_REQUIRED, 'Locale d’affichage', 'fr_FR')
+            ->addOption('timezone', null, InputOption::VALUE_REQUIRED, 'Fuseau horaire (ex: Europe/Paris)', 'Europe/Paris')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Limiter le nombre de lignes affichées', '0');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $trackingNumber = (string) $input->getArgument('trackingNumber');
+        $locale  = (string) $input->getOption('locale');
+        $tzName  = (string) $input->getOption('timezone');
+        $limit   = (int) $input->getOption('limit');
+
+        try {
+            $events = $this->trackingService->trackShipment($trackingNumber, includeDetailedScans: true, locale: $locale);
+        } catch (\Throwable $e) {
+            $output->writeln('<error>Erreur lors de l’appel FedEx : ' . $e->getMessage() . '</error>');
+            return Command::FAILURE;
+        }
+
+        if (empty($events)) {
+            $output->writeln('<comment>Aucun événement trouvé pour ce numéro.</comment>');
+            return Command::SUCCESS;
+        }
+
+        // Optionnel : limiter le nombre d’événements affichés
+        if ($limit > 0) {
+            $events = \array_slice($events, 0, $limit);
+        }
+
+        $table = new Table($output);
+        $table->setHeaders(['Date', 'Ville / Pays', 'Description']);
+
+        $timezone = new \DateTimeZone($tzName);
+
+        /** @var FedexTrackingEvent $event */
+        foreach ($events as $event) {
+            $date = $event->date->setTimezone($timezone);
+
+            // Format date FR simple : 15/08/2025 13:37
+            $dateStr = $date->format('d/m/Y H:i');
+
+            $location = trim(implode(' / ', array_filter([
+                $event->city ?: null,
+                $event->country ?: null,
+            ])));
+
+            $table->addRow([
+                $dateStr,
+                $location !== '' ? $location : '-',
+                $event->description,
+            ]);
+        }
+
+        $output->writeln(sprintf('<info>Numéro :</info> %s', $trackingNumber));
+        $table->render();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/DependencyInjection/FedexExtension.php
+++ b/src/DependencyInjection/FedexExtension.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\Config\FileLocator;
 
-class FedexBundleExtension extends Extension
+class FedexExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/src/FedexBundle.php
+++ b/src/FedexBundle.php
@@ -2,9 +2,15 @@
 
 namespace SonnyDev\FedexBundle;
 
+use SonnyDev\FedexBundle\DependencyInjection\FedexExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-class FedexBundle extends Bundle
+final class FedexBundle extends Bundle
 {
+    public function getContainerExtension(): ?ExtensionInterface
+    {
+        return new FedexExtension();
+    }
 
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -13,7 +13,8 @@ return static function (ContainerConfigurator $config): void {
 
     $services->load('SonnyDev\\FedexBundle\\', __DIR__ . '/../../')
         ->exclude([__DIR__ . '/../../DependencyInjection/', __DIR__ . '/../../Entity/', __DIR__ . '/../../Tests/']);
-
+     $services->load('SonnyDev\\FedexBundle\\Command\\', __DIR__.'/../../Command/')
+         ->tag('console.command');
     // Paramètres spécifiques avec injection depuis .env
     $services->get(FedexTrackingService::class)
         ->arg('$fedexApiTracking', '%env(FEDEX_API_TRACKING)%');
@@ -25,4 +26,6 @@ return static function (ContainerConfigurator $config): void {
         ->arg('$fedexClientShipSecret', '%env(FEDEX_CLIENT_SHIP_SECRET)%')
         ->arg('$fedexOauthToken', '%env(FEDEX_CLIENT_AUTH_LINK)%')
         ->arg('$fedexApiTracking', '%env(FEDEX_API_TRACKING)%');
+
+
 };


### PR DESCRIPTION
feat(cli): créer la commande fedex:track pour afficher les événements de tracking (#3)

- Ajout d'une commande CLI `fedex:track`
- Affichage formaté des événements (date, ville/pays, description)
- Support des options --timezone et --locale
