### PR TITLE
test(tracking): ajouter un test unitaire pour trackShipment avec payl…

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,41 @@
+<?php
+
+$finder = (new PhpCsFixer\Finder())
+    ->in(__DIR__)
+    ->exclude('var')
+    ->exclude('vendor')
+;
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PhpCsFixer' => true,
+        '@DoctrineAnnotation' => true,
+        '@PHP71Migration' => true,
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'cast_spaces' => ['space' => 'none'],
+        'concat_space' => ['spacing' => 'one'],
+        'escape_implicit_backslashes' => false,
+        'explicit_indirect_variable' => false,
+        'explicit_string_variable' => false,
+        'no_superfluous_elseif' => false,
+        'ordered_class_elements' => false,
+        'php_unit_internal_class' => false,
+        'phpdoc_order_by_value' => false,
+        'phpdoc_align' => ['align' => 'left'],
+        'phpdoc_summary' => false,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'simple_to_complex_string_variable' => false,
+        'native_constant_invocation' => false,
+        'native_function_invocation' => false,
+        'general_phpdoc_annotation_remove' => ['annotations' => ['author', 'package']],
+        'global_namespace_import' => true,
+        'linebreak_after_opening_tag' => true,
+        'no_php4_constructor' => true,
+        'pow_to_exponentiation' => true,
+        'random_api_migration' => true,
+        'list_syntax' => ['syntax' => 'short'],
+        'method_chaining_indentation' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "symfony/framework-bundle": "^6.1|^7.0",
         "symfony/asset-mapper": "^6.3|^7.0",
         "friendsoftwig/twigcs": "^6.4",
-        "dg/bypass-finals": "^1.6"
+        "dg/bypass-finals": "^1.6",
+        "symfony/test-pack": "^1.1"
     },
     "autoload": {
         "psr-4": {
@@ -57,13 +58,14 @@
         }
     },
     "scripts": {
-        "phpcsfixer": "./vendor/bin/php-cs-fixer fix",
+        "phpcsfixer": "./vendor/bin/php-cs-fixer fix --allow-risky=yes",
         "phpcsfixer-lint": "./vendor/bin/php-cs-fixer fix --dry-run --diff",
         "twig-cs-lint": "./vendor/bin/twigcs ./src/templates/",
         "phpstan": "./vendor/bin/phpstan --memory-limit=1G analyse",
         "rector":  "./vendor/bin/rector process --dry-run",
         "rector-nocache":  "./vendor/bin/rector process --dry-run --clear-cache",
         "rector-no-dry":  "./vendor/bin/rector process",
+        "phpunit":  "./vendor/bin/phpunit --testdox tests/",
         "ci": [
             "@phpcsfixer-lint",
             "@phpstan",

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,5 @@
+parameters:
+    inferPrivatePropertyTypeFromConstructor: true
+    level: 8
+    paths:
+        - src

--- a/src/DTO/FedexTrackingEvent.php
+++ b/src/DTO/FedexTrackingEvent.php
@@ -2,6 +2,7 @@
 
 namespace SonnyDev\FedexBundle\DTO;
 
+use DateTimeImmutable;
 use Exception;
 
 class FedexTrackingEvent
@@ -9,24 +10,28 @@ class FedexTrackingEvent
     public function __construct(
         public readonly string $type,
         public readonly string $description,
-        public readonly \DateTimeImmutable $date,
+        public readonly DateTimeImmutable $date,
         public readonly ?string $city,
-        public readonly ?string $country
-    ) {}
+        public readonly ?string $country,
+    ) {
+    }
 
     /**
-     * @param array $event
-     * @return self
+     * @param array<string, mixed> $event
      * @throws Exception
      */
-    public static function fromApi(array $event): self
+    public static function fromApi(array $event = []): self
     {
+        $scanLocation = $event['scanLocation'] ?? [];
+        $city = is_array($scanLocation) ? ($scanLocation['city'] ?? null) : null;
+        $country = is_array($scanLocation) ? ($scanLocation['countryName'] ?? null) : null;
+
         return new self(
-            type: $event['eventType'] ?? 'UNKNOWN',
-            description: $event['eventDescription'] ?? 'No description',
+            type: $event['eventType'] ?? '',
+            description: $event['eventDescription'] ?? '',
             date: new \DateTimeImmutable($event['date'] ?? 'now'),
-            city: $event['scanLocation']['city'] ?? null,
-            country: $event['scanLocation']['countryName'] ?? null,
+            city: $city,
+            country: $country
         );
     }
 }

--- a/src/DependencyInjection/FedexExtension.php
+++ b/src/DependencyInjection/FedexExtension.php
@@ -2,10 +2,10 @@
 
 namespace SonnyDev\FedexBundle\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\Config\FileLocator;
 
 class FedexExtension extends Extension
 {

--- a/src/Exception/FedexApiException.php
+++ b/src/Exception/FedexApiException.php
@@ -1,15 +1,21 @@
 <?php
+declare(strict_types=1);
 
 namespace SonnyDev\FedexBundle\Exception;
 
+use RuntimeException;
+use Throwable;
 
-class FedexApiException extends \RuntimeException
+class FedexApiException extends RuntimeException
 {
+    /**
+     * @param array<string, mixed>|null $responseData
+     */
     public function __construct(
         string $message,
         public readonly ?int $statusCode = null,
         public readonly ?array $responseData = null,
-        \Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, 0, $previous);
     }

--- a/src/FedexBundle.php
+++ b/src/FedexBundle.php
@@ -3,14 +3,10 @@
 namespace SonnyDev\FedexBundle;
 
 use SonnyDev\FedexBundle\DependencyInjection\FedexExtension;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 final class FedexBundle extends Bundle
 {
-    public function getContainerExtension(): ?ExtensionInterface
-    {
-        return new FedexExtension();
-    }
 
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -1,23 +1,33 @@
 <?php
+
 declare(strict_types=1);
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use SonnyDev\FedexBundle\Service\FedexTrackingService;
 use SonnyDev\FedexBundle\Service\FedexAuthenticator;
+use SonnyDev\FedexBundle\Service\FedexTrackingService;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $config): void {
     $services = $config->services()
         ->defaults()
         ->autowire()
-        ->autoconfigure();
+        ->autoconfigure()
+    ;
 
     $services->load('SonnyDev\\FedexBundle\\', __DIR__ . '/../../')
-        ->exclude([__DIR__ . '/../../DependencyInjection/', __DIR__ . '/../../Entity/', __DIR__ . '/../../Tests/']);
-     $services->load('SonnyDev\\FedexBundle\\Command\\', __DIR__.'/../../Command/')
-         ->tag('console.command');
-    // Paramètres spécifiques avec injection depuis .env
+        ->exclude([
+            __DIR__ . '/../../DependencyInjection/',
+            __DIR__ . '/../../Resources/',
+            __DIR__ . '/../../Entity/',
+            __DIR__ . '/../../Tests/',
+        ]);
+
+    $services->load('SonnyDev\FedexBundle\Command\\', __DIR__ . '/../../Command/')
+        ->tag('console.command')
+    ;
+
     $services->get(FedexTrackingService::class)
-        ->arg('$fedexApiTracking', '%env(FEDEX_API_TRACKING)%');
+        ->arg('$fedexApiTracking', '%env(FEDEX_API_TRACKING)%')
+    ;
 
     $services->get(FedexAuthenticator::class)
         ->arg('$fedexClientId', '%env(FEDEX_CLIENT_ID)%')
@@ -26,6 +36,4 @@ return static function (ContainerConfigurator $config): void {
         ->arg('$fedexClientShipSecret', '%env(FEDEX_CLIENT_SHIP_SECRET)%')
         ->arg('$fedexOauthToken', '%env(FEDEX_CLIENT_AUTH_LINK)%')
         ->arg('$fedexApiTracking', '%env(FEDEX_API_TRACKING)%');
-
-
 };

--- a/src/Service/FedexAuthenticator.php
+++ b/src/Service/FedexAuthenticator.php
@@ -4,6 +4,7 @@ namespace SonnyDev\FedexBundle\Service;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
+use RuntimeException;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
@@ -18,14 +19,11 @@ class FedexAuthenticator
         private readonly CacheItemPoolInterface $cache,
         private readonly string $fedexClientId,
         private readonly string $fedexClientSecret,
-        private readonly string $fedexClientShipId,
-        private readonly string $fedexClientShipSecret,
         private readonly string $fedexOauthToken,
-        private readonly string $fedexApiTracking
-    ) {}
+    ) {
+    }
 
     /**
-     * @return string
      * @throws InvalidArgumentException
      * @throws ClientExceptionInterface
      * @throws DecodingExceptionInterface
@@ -54,13 +52,13 @@ class FedexAuthenticator
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            throw new \RuntimeException('FedEx API returned error: ' . $response->getStatusCode());
+            throw new RuntimeException('FedEx API returned error: ' . $response->getStatusCode());
         }
 
         $data = $response->toArray();
 
         if (!isset($data['access_token'])) {
-            throw new \RuntimeException('No access_token in FedEx response');
+            throw new RuntimeException('No access_token in FedEx response');
         }
 
         $token = $data['access_token'];

--- a/tests/FedexTrackingServiceTest.php
+++ b/tests/FedexTrackingServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SonnyDev\FedexBundle\Tests;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use SonnyDev\FedexBundle\DTO\FedexTrackingEvent;
+use SonnyDev\FedexBundle\Service\FedexAuthenticator;
+use SonnyDev\FedexBundle\Service\FedexTrackingService;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * @coversNothing
+ */
+final class FedexTrackingServiceTest extends TestCase
+{
+    public function testTrackShipmentMapsValidEvents(): void
+    {
+        // 1) Mock authenticator -> token
+        $auth = $this->createMock(FedexAuthenticator::class);
+        $auth->method('getAccessToken')->willReturn('fake-token');
+
+        // 2) Payload FedEx simulé (structure réelle simplifiée)
+        $fedexPayload = [
+            'output' => [
+                'completeTrackResults' => [
+                    [
+                        'trackResults' => [
+                            [
+                                'scanEvents' => [
+                                    [
+                                        'eventType' => 'PU',
+                                        'eventDescription' => 'Shipment picked up',
+                                        'date' => '2025-08-10T09:15:00Z',
+                                        'scanLocation' => [
+                                            'city' => 'Paris',
+                                            'countryName' => 'France',
+                                        ],
+                                    ],
+                                    [
+                                        'eventType' => 'AR',
+                                        'eventDescription' => 'Arrived at FedEx location',
+                                        'date' => '2025-08-11T13:45:00Z',
+                                        'scanLocation' => [
+                                            'city' => 'Roissy',
+                                            'countryName' => 'France',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        // 3) Mock HTTP -> renvoie le JSON ci-dessus
+        $response = new MockResponse(json_encode($fedexPayload), [
+            'http_code' => 200,
+            'response_headers' => ['content-type' => 'application/json'],
+        ]);
+
+        $httpClient = new MockHttpClient($response);
+
+        // 4) Service sous test
+        $service = new FedexTrackingService(
+            httpClient: $httpClient,
+            authenticator: $auth,
+            fedexApiTracking: 'https://apis-sandbox.fedex.com/track/v1/trackingnumbers',
+        );
+
+        // 5) Appel
+        $events = $service->trackShipment('123456789012', includeDetailedScans: true, locale: 'fr_FR');
+
+        $this->assertIsArray($events);
+        $this->assertCount(2, $events);
+
+        // On reçoit bien des DTO
+        $this->assertContainsOnlyInstancesOf(FedexTrackingEvent::class, $events);
+
+        // Le plus récent d’abord (AR du 11/08 avant PU du 10/08)
+        $first = $events[0];
+        $this->assertSame('AR', $first->type);
+        $this->assertSame('Arrived at FedEx location', $first->description);
+        $this->assertInstanceOf(DateTimeImmutable::class, $first->date);
+        $this->assertSame('Roissy', $first->city);
+        $this->assertSame('France', $first->country);
+
+        $second = $events[1];
+        $this->assertSame('PU', $second->type);
+        $this->assertSame('Shipment picked up', $second->description);
+        $this->assertInstanceOf(DateTimeImmutable::class, $second->date);
+        $this->assertSame('Paris', $second->city);
+        $this->assertSame('France', $second->country);
+    }
+
+    public function testTrackShipmentHandlesEmptyResults(): void
+    {
+        $auth = $this->createMock(FedexAuthenticator::class);
+        $auth->method('getAccessToken')->willReturn('fake-token');
+
+        $fedexPayload = ['output' => ['completeTrackResults' => []]];
+        $response = new MockResponse(json_encode($fedexPayload), [
+            'http_code' => 200,
+            'response_headers' => ['content-type' => 'application/json'],
+        ]);
+        $httpClient = new MockHttpClient($response);
+
+        $service = new FedexTrackingService(
+            httpClient: $httpClient,
+            authenticator: $auth,
+            fedexApiTracking: 'https://apis-sandbox.fedex.com/track/v1/trackingnumbers',
+        );
+
+        $events = $service->trackShipment('123456789012');
+
+        $this->assertIsArray($events);
+        $this->assertCount(0, $events);
+    }
+}


### PR DESCRIPTION
test(tracking): ajouter un test unitaire pour trackShipment avec payload FedEx simulé (#3)

- Mock de l’authentification et de la réponse HTTP
- Vérification du mapping vers FedexTrackingEvent
- Gestion du cas sans événements
